### PR TITLE
Support Venafi Cloud & Remove API functions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,13 +2,6 @@
 driver:
   name: vagrant
 
-driver_config:
-  network:
-  - ["forwarded_port", {guest: 80, host: 8080, host_ip: "127.0.0.1"}]
-  - ["forwarded_port", {guest: 443, host: 8443, host_ip: "127.0.0.1"}]
-  - ["forwarded_port", {guest: 8080, host: 9080, host_ip: "127.0.0.1"}]
-  - ["forwarded_port", {guest: 8443, host: 9443, host_ip: "127.0.0.1"}]  
-
 provisioner:
   name: chef_zero
   product_name: chef
@@ -26,9 +19,42 @@ platforms:
 
 suites:
   - name: default
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 8080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 8443, host_ip: "127.0.0.1"}]
     run_list:
-      - recipe[venafi-helper-tomcat::default]
+      - recipe[venafi-helper-httpd::default]
     verifier:
       inspec_tests:
         - test/integration/default
     attributes:
+      venafi-helper-httpd:
+        url: 'https://venafi-ecosystem-tpp.cld.sr/vedsdk/'
+        username: "<%= ENV['VENAFI_USERNAME'] %>"
+        password: "<%= ENV['VENAFI_PASSWORD'] %>"
+        zone: 'Venafi Partners\Indellient\Infra'
+        common_name: 'test.example.com'
+        location: '/etc/venafi'
+        app_info: 'test'
+        tls_address: '33.33.33.33:443'
+        app_name: 'app_name'
+        renew_threshold: 1
+        # device_name: 'devicename'
+  - name: cloud
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 10080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 10443, host_ip: "127.0.0.1"}]
+    run_list:
+      - recipe[venafi-helper-httpd::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      venafi-helper-httpd:
+        apikey: "<%= ENV['VENAFI_APIKEY'] %>"
+        zone: '582d5560-a9a7-11ea-8a4f-3f9fa45442b2'
+        common_name: 'test.indellient.com'
+        location: '/etc/venafi'
+        renew_threshold: 15

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ platforms:
   - name: centos-7
 
 suites:
-  - name: default
+  - name: httpd-tpp
     driver_config:
       network:
       - ["forwarded_port", {guest: 80, host: 8080, host_ip: "127.0.0.1"}]
@@ -40,8 +40,7 @@ suites:
         tls_address: '33.33.33.33:443'
         app_name: 'app_name'
         renew_threshold: 1
-        # device_name: 'devicename'
-  - name: cloud
+  - name: http-cloud
     driver_config:
       network:
       - ["forwarded_port", {guest: 80, host: 10080, host_ip: "127.0.0.1"}]
@@ -53,6 +52,84 @@ suites:
         - test/integration/default
     attributes:
       venafi-helper-httpd:
+        apikey: "<%= ENV['VENAFI_APIKEY'] %>"
+        zone: '582d5560-a9a7-11ea-8a4f-3f9fa45442b2'
+        common_name: 'test.indellient.com'
+        location: '/etc/venafi'
+        renew_threshold: 15
+  - name: nginx-tpp
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 8080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 8443, host_ip: "127.0.0.1"}]
+    run_list:
+      - recipe[venafi-helper-nginx::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      venafi-helper-nginx:
+        url: 'https://venafi-ecosystem-tpp.cld.sr/vedsdk/'
+        username: "<%= ENV['VENAFI_USERNAME'] %>"
+        password: "<%= ENV['VENAFI_PASSWORD'] %>"
+        zone: 'Venafi Partners\Indellient\Infra'
+        common_name: 'test.example.com'
+        location: '/etc/venafi'
+        app_info: 'test'
+        tls_address: '33.33.33.33:443'
+        app_name: 'app_name'
+        renew_threshold: 1
+  - name: nginx-cloud
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 10080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 10443, host_ip: "127.0.0.1"}]
+    run_list:
+      - recipe[venafi-helper-nginx::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      venafi-helper-nginx:
+        apikey: "<%= ENV['VENAFI_APIKEY'] %>"
+        zone: '582d5560-a9a7-11ea-8a4f-3f9fa45442b2'
+        common_name: 'test.indellient.com'
+        location: '/etc/venafi'
+        renew_threshold: 15
+  - name: tomcat-tpp
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 8080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 8443, host_ip: "127.0.0.1"}]
+    run_list:
+      - recipe[venafi-helper-tomcat::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      venafi-helper-tomcat:
+        url: 'https://venafi-ecosystem-tpp.cld.sr/vedsdk/'
+        username: "<%= ENV['VENAFI_USERNAME'] %>"
+        password: "<%= ENV['VENAFI_PASSWORD'] %>"
+        zone: 'Venafi Partners\Indellient\Infra'
+        common_name: 'test.example.com'
+        location: '/etc/venafi'
+        app_info: 'test'
+        tls_address: '33.33.33.33:443'
+        app_name: 'app_name'
+        renew_threshold: 1
+  - name: tomcat-cloud
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 10080, host_ip: "127.0.0.1"}]
+      - ["forwarded_port", {guest: 443, host: 10443, host_ip: "127.0.0.1"}]
+    run_list:
+      - recipe[venafi-helper-tomcat::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:
+      venafi-helper-tomcat:
         apikey: "<%= ENV['VENAFI_APIKEY'] %>"
         zone: '582d5560-a9a7-11ea-8a4f-3f9fa45442b2'
         common_name: 'test.indellient.com'

--- a/README.md
+++ b/README.md
@@ -1,32 +1,27 @@
-# venafi-helper
+# Venafi Helper Cookbook
 
 ### Description
-This is a venafi cookbook whuck will connect with an existing TPP (Trust Protection Platform) Venafi Server and enroll and manage your certs. 
 
-In order to use the venafi-helper you need to port the custim resource and call it from your default recipe. 
+This is a venafi cookbook which will connect with an existing TPP (Trust Protection Platform) Venafi Server or Venafi Cloud, and enroll and manage your certs. 
 
-in order to use the venafi-helper, you also need to install the ruby gem `vcert`
+In order to use the venafi-helper you need to utilize the custom resource and call it from your recipes. 
 
-### Configuring the venafi-helper
-| Configuration     | Description                                                                           |
-|-------------------|---------------------------------------------------------------------------------------|
-|`tpp_username`     | The username you use to authenticate with the SDK                                     |
-|`tpp_password`     | The password you use to authenticate with the SDK                                     |
-|`policyname`       | The zone of your certificate (e.g. "Certificates\\\\Bla").                            |
-|`commonname`       | The common name of your certificate (e.g. "bla.example.com").                         |
-|`location`         | Where you want to write the certificates to disk                                      |
-|`devicename`       | Name of Device you want to create in Venafi Server                                    |
+### venafihelper Properties
 
-In your default recipe you would call the venafi-helper custom resource and set the configuration as such: 
+- `common_name`: The common name of your certificate (e.g. "bla.example.com")
+  - name property
+- `tpp_url`: The URL you use to authenticate with the SDK
+- `tpp_username`: The username you use to authenticate with the SDK
+- `tpp_password`: The password you use to authenticate with the SDK
+- `zone`: The zone of your certificate (e.g. "Certificates\\\\Bla")
+- `location`: Where you want to write the certificates to disk
+- `device_name`: Name of Device you want to create in Venafi Server
+  - default: node FQDN
+- `app_name`:
+- `apikey`: API used to communicate with Venafi Cloud
+- `id_path`:
+- `app_info`:
+- `tls_address`:
+- `renew_threshold`:
 
-```
-venafi-helper 'tpp_url' do
-    tpp_username 'tppusername'
-    tpp_password 'tpppassword'
-    policyname   'Policyname'
-    commonname   'commonname'
-    location     'location'
-    devicename   'devicename'
-    action :run
-end
-```
+For examples please see the test fixtures in the `test/` directory.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,62 @@
+module VenafiCookbook
+  module Helper
+    extend Chef::Mixin::ShellOut
+
+    def version
+      '4.9.6'
+    end
+
+    def what_is_this
+      '+895'
+    end
+
+    def platform
+      'linux86'
+    end
+
+    def venafi_download_url
+      "https://github.com/Venafi/vcert/releases/download/v#{version}/vcert-v4.9.6#{what_is_this}_#{platform}"
+    end
+
+    def venafi_install_path
+      '/usr/local/bin/vcert'
+    end
+
+    def enroll(apikey:, zone:, cert_path:, key_path:, chain_path:, common_name:, id_path:, tpp_username:, tpp_password:, tpp_url:, instance:, app_info:, tls_address:)
+      cmd = "#{venafi_install_path} enroll -no-prompt"
+      cmd << " -k '#{apikey}'" if apikey
+      cmd << " -tpp-user '#{tpp_username}' -tpp-password '#{tpp_password}' -u '#{tpp_url}'" if tpp_url
+      cmd << " -z '#{zone}'" if zone
+      cmd << " -cert-file '#{cert_path}'" if cert_path
+      cmd << " -key-file '#{key_path}'" if key_path
+      cmd << " -chain-file '#{chain_path}'" if chain_path
+      cmd << " -pickup-id-file '#{id_path}'" if id_path
+      cmd << " -cn '#{common_name}'" if common_name
+      cmd << " -instance '#{instance}' -replace-instance -app-info '#{app_info}' -tls-address '#{tls_address}'" if instance && app_info && tls_address
+      cmd
+    end
+
+    def renew(apikey:, zone:, cert_path:, key_path:, chain_path:, common_name:, id_path:, tpp_username:, tpp_password:, tpp_url:)
+      cmd = "#{venafi_install_path} renew -no-prompt"
+      cmd << " -k '#{apikey}'" if apikey
+      cmd << " -tpp-user '#{tpp_username}' -tpp-password '#{tpp_password}' -u '#{tpp_url}'" if tpp_url
+      cmd << " -z '#{zone}'" if zone
+      cmd << " -cert-file '#{cert_path}'" if cert_path
+      cmd << " -key-file '#{key_path}'" if key_path
+      cmd << " -chain-file '#{chain_path}'" if chain_path
+      cmd << " -id file:#{id_path}" if id_path
+      cmd
+    end
+
+    def should_renew?(cert_path:, renew_threshold:)
+      return false unless renew_threshold
+      valid_to = shell_out("cut -d \"=\" -f2 <<< $(openssl x509 -enddate -noout -in #{cert_path})").stdout
+      valid_to_epoch = shell_out("date -d \"#{valid_to}\" +\"%s\"").stdout
+      curr_date = shell_out('date "+%s"').stdout
+      (renew_threshold * 86400 + curr_date.to_i) > valid_to_epoch.to_i
+    end
+  end
+end
+
+Chef::Resource.send(:include, VenafiCookbook::Helper)
+Chef::Recipe.send(:include, VenafiCookbook::Helper)

--- a/resources/venafihelper.rb
+++ b/resources/venafihelper.rb
@@ -15,33 +15,26 @@ property :tls_address, String
 property :renew_threshold, Integer
 
 action :run do
-  tpp_url = new_resource.tpp_url
-  tpp_username = new_resource.tpp_username
-  tpp_password = new_resource.tpp_password
-  zone = new_resource.zone
-  common_name = new_resource.common_name
-  device_name = new_resource.device_name
   app_name = new_resource.app_name
-  instance = device_name
+  instance = new_resource.device_name
   instance = "#{instance}:#{app_name}" if app_name
 
-  apikey = new_resource.apikey
-  id_path = new_resource.id_path
-  app_info = new_resource.app_info
-  tls_address = new_resource.tls_address
-
+  common_name = new_resource.common_name
   cert_file = "#{common_name}.cert"
   key_file = "#{common_name}.key"
   chain_file = "#{common_name}.chain"
   id_file = "#{common_name}.id"
 
   location = new_resource.location
+  id_path = new_resource.id_path
   cert_path = "#{location}/#{cert_file}"
   key_path = "#{location}/#{key_file}"
   chain_path = "#{location}/#{chain_file}"
   id_path = "#{location}/#{id_file}"
 
-  ::Chef::Application.fatal!('Device Registration not supported on Venafi Cloud') if !instance.nil? && !app_info.nil? && !tls_address.nil? && !apikey.nil?
+  if !instance.nil? && !new_resource.app_info.nil? && !new_resource.tls_address.nil? && !apikey.nil?
+    ::Chef::Application.fatal!('Device Registration not supported on Venafi Cloud')
+  end
 
   remote_file venafi_install_path do
     source venafi_download_url
@@ -53,19 +46,19 @@ action :run do
 
   execute 'enroll' do
     command enroll(
-      apikey: apikey,
-      zone: zone,
+      apikey: new_resource.apikey,
+      zone: new_resource.zone,
       cert_path: cert_path,
       key_path: key_path,
       chain_path: chain_path,
       common_name: common_name,
       id_path: id_path,
-      tpp_username: tpp_username,
-      tpp_password: tpp_password,
-      tpp_url: tpp_url,
+      tpp_username: new_resource.tpp_username,
+      tpp_password: new_resource.tpp_password,
+      tpp_url: new_resource.tpp_url,
       instance: instance,
-      app_info: app_info,
-      tls_address: tls_address
+      app_info: new_resource.app_info,
+      tls_address: new_resource.tls_address
     )
     sensitive true
     not_if { ::File.exist?(cert_path) && ::File.exist?(key_path) && ::File.exist?(chain_path) }
@@ -73,16 +66,16 @@ action :run do
 
   execute 'renew' do
     command renew(
-      apikey: apikey,
-      zone: zone,
+      apikey: new_resource.apikey,
+      zone: new_resource.zone,
       cert_path: cert_path,
       key_path: key_path,
       chain_path: chain_path,
       common_name: common_name,
       id_path: id_path,
-      tpp_username: tpp_username,
-      tpp_password: tpp_password,
-      tpp_url: tpp_url
+      tpp_username: new_resource.tpp_username,
+      tpp_password: new_resource.tpp_password,
+      tpp_url: new_resource.tpp_url
     )
     sensitive true
     only_if { should_renew?(cert_path: cert_path, renew_threshold: new_resource.renew_threshold) }

--- a/resources/venafihelper.rb
+++ b/resources/venafihelper.rb
@@ -1,187 +1,94 @@
 resource_name :venafihelper
 
-property :tpp_url, String, name_property: true
+property :common_name, String, name_property: true
+property :tpp_url, String
 property :tpp_password, String
 property :tpp_username, String
-property :policyname, String
-property :commonname, String
+property :zone, String
 property :location, String
-property :devicename, String
-
-require 'json'
-require 'net/http'
-require 'uri'
-require 'openssl'
-require 'base64'
-require 'socket'
-require 'date'
-require 'fileutils'
-
+property :device_name, String, default: node['fqdn']
+property :app_name, String
+property :apikey, String
+property :id_path, String
+property :app_info, String
+property :tls_address, String
+property :renew_threshold, Integer
 
 action :run do
-  require 'vcert'
-  TPP_URL = "#{new_resource.tpp_url}"
-  TPP_SDK_URL = "#{TPP_URL}/vedsdk/"
-  TPP_USERNAME = "#{new_resource.tpp_username}"
-  TPP_PASSWORD = "#{new_resource.tpp_password}"
-  CERTIFICATE_ZONE = "#{new_resource.policyname}"
-  COMMON_NAME = "#{new_resource.commonname}"
-  DEVICE_NAME = "#{new_resource.devicename}"
+  tpp_url = new_resource.tpp_url
+  tpp_username = new_resource.tpp_username
+  tpp_password = new_resource.tpp_password
+  zone = new_resource.zone
+  common_name = new_resource.common_name
+  device_name = new_resource.device_name
+  app_name = new_resource.app_name
+  instance = device_name
+  instance = "#{instance}:#{app_name}" if app_name
 
-  CERT_FILE="#{COMMON_NAME}.cert"
-  KEY_FILE="#{COMMON_NAME}.key"
-  CHAIN_FILE="#{COMMON_NAME}.chain"
+  apikey = new_resource.apikey
+  id_path = new_resource.id_path
+  app_info = new_resource.app_info
+  tls_address = new_resource.tls_address
 
-  PATH = "#{new_resource.location}"
-  CERT_PATH="#{PATH}/#{CERT_FILE}"
-  KEY_PATH="#{PATH}/#{KEY_FILE}"
-  CHAIN_PATH="#{PATH}/#{CHAIN_FILE}"
-  CERT_ID="\\VED\\Policy\\#{CERTIFICATE_ZONE}\\#{COMMON_NAME}"
+  cert_file = "#{common_name}.cert"
+  key_file = "#{common_name}.key"
+  chain_file = "#{common_name}.chain"
+  id_file = "#{common_name}.id"
 
-  TOKEN_HEADER_NAME = "x-venafi-api-key"
-  URL_AUTHORIZE = "/authorize/"
-  URL_CONFIG_CREATE = "/config/create"
-  URL_CERT_ASSOCIATE = "/certificates/associate"
-  URL_CERTIFICATE_SEARCH = "/certificates/"
+  location = new_resource.location
+  cert_path = "#{location}/#{cert_file}"
+  key_path = "#{location}/#{key_file}"
+  chain_path = "#{location}/#{chain_file}"
+  id_path = "#{location}/#{id_file}"
 
-  @conn = Vcert::Connection.new url: TPP_URL, user: TPP_USERNAME, password: TPP_PASSWORD
-  @zone_config = @conn.zone_configuration(CERTIFICATE_ZONE)
+  ::Chef::Application.fatal!('Device Registration not supported on Venafi Cloud') if !instance.nil? && !app_info.nil? && !tls_address.nil? && !apikey.nil?
 
-  # apikey = authorize['APIKey']
-  # puts "API-key #{apikey}"
-  if !(::File.exists?("#{CERT_PATH}"))
-    requestAndRetrieve
-    # sleep(60)
-    # apikey = authorize['APIKey']
-    # puts "API-key #{apikey}"
-    # retrievecert(apikey)
-    # apikey = authorize['APIKey']
-    deviceCreation
+  remote_file venafi_install_path do
+    source venafi_download_url
+    mode '0755'
+    action :create
   end
 
-  checkExpiry
+  directory location
+
+  execute 'enroll' do
+    command enroll(
+      apikey: apikey,
+      zone: zone,
+      cert_path: cert_path,
+      key_path: key_path,
+      chain_path: chain_path,
+      common_name: common_name,
+      id_path: id_path,
+      tpp_username: tpp_username,
+      tpp_password: tpp_password,
+      tpp_url: tpp_url,
+      instance: instance,
+      app_info: app_info,
+      tls_address: tls_address
+    )
+    sensitive true
+    not_if { ::File.exist?(cert_path) && ::File.exist?(key_path) && ::File.exist?(chain_path) }
+  end
+
+  execute 'renew' do
+    command renew(
+      apikey: apikey,
+      zone: zone,
+      cert_path: cert_path,
+      key_path: key_path,
+      chain_path: chain_path,
+      common_name: common_name,
+      id_path: id_path,
+      tpp_username: tpp_username,
+      tpp_password: tpp_password,
+      tpp_url: tpp_url
+    )
+    sensitive true
+    only_if { should_renew?(cert_path: cert_path, renew_threshold: new_resource.renew_threshold) }
+  end
 end
 
-
 action_class do
-  
-  def authorize
-    uri = URI.parse(TPP_SDK_URL)
-    request = Net::HTTP.new(uri.host, uri.port)
-    request.use_ssl = true
-    url = uri.path + URL_AUTHORIZE
-    data = {:Username => TPP_USERNAME, :Password => TPP_PASSWORD}
-    encoded_data = JSON.generate(data)
-    response = request.post(url, encoded_data, {"Content-Type" => "application/json"})
-    data = JSON.parse(response.body)
-    token = data['APIKey']
-    valid_until = DateTime.strptime(data['ValidUntil'].gsub(/\D/, ''), '%Q')
-    @token = token, valid_until
-  end
-
-  def post(url, data)
-    if @token == nil || @token[1] < DateTime.now
-      authorize()
-    end
-    uri = URI.parse(TPP_SDK_URL)
-    request = Net::HTTP.new(uri.host, uri.port)
-    request.use_ssl = true
-    url = uri.path + url
-    encoded_data = JSON.generate(data)
-    response = request.post(url, encoded_data, {TOKEN_HEADER_NAME => @token[0], "Content-Type" => "application/json"})
-    data = JSON.parse(response.body)
-    return response.code.to_i, data
-  end
-
-  def get(url)
-    if @token == nil || @token[1] < DateTime.now
-      authorize()
-    end
-    uri = URI.parse(TPP_SDK_URL)
-    request = Net::HTTP.new(uri.host, uri.port)
-    request.use_ssl = true
-    url = uri.path + url
-    response = request.get(url, {TOKEN_HEADER_NAME => @token[0]})
-    data = JSON.parse(response.body)
-    return response.code.to_i, data
-  end
-
-  def requestAndRetrieve
-    
-    request = Vcert::Request.new common_name: COMMON_NAME
-
-    request.update_from_zone_config(@zone_config)
-
-    certificate = @conn.request_and_retrieve(request, CERTIFICATE_ZONE, timeout: 600)
-
-    puts "Private Key is:\n#{request.private_key}"
-    puts "Certificate is:\n#{certificate.cert}"
-    puts "Chain is:\n#{certificate.chain.join("")}"
-
-    ::FileUtils.mkpath "#{PATH}"
-    
-    ::File.open("#{CERT_PATH}", "w+") {|f| f.write("#{certificate.cert}") }
-    ::File.open("#{KEY_PATH}", "w+") {|f| f.write("#{request.private_key}") }
-    ::File.open("#{CHAIN_PATH}", "w+") {|f| f.write("#{certificate.chain.join("")}") }
-  end
-
-  def deviceCreation
-    ip = Socket.ip_address_list.detect{|intf| intf.ipv4_private?}
-    deviceDN = "\\VED\\Policy\\Devices and Applications\\External\\#{DEVICE_NAME}"
-    applicationDN = "#{deviceDN}\\#{COMMON_NAME}-#{ip.ip_address}/#{Socket.gethostname}"
-
-    deviceCreationData = {:ObjectDN => deviceDN, :Class => "Device", :NameAttributeList =>[{:Name => "Description", :Value => "Value"}]}
-    applicationCreationData = {:ObjectDN => applicationDN, :Class => "Basic", :NameAttributeList =>[{:Name => "Description", :Value => "Basic Application for certificate #{COMMON_NAME}"},{:Name => "Disabled", :Value => "0"}]}
-    associateData = {:ApplicationDN => applicationDN, :CertificateDN => CERT_ID}
-    
-    deviceCode, deviceResponse = post URL_CONFIG_CREATE, deviceCreationData
-    if deviceCode != 200
-      return nil
-    end
-    puts deviceResponse
-
-    applicationCode, applicationResponse = post URL_CONFIG_CREATE, applicationCreationData
-    if applicationCode != 200
-      return nil
-    end
-    puts applicationResponse
-
-    associateCode, associateResponse = post URL_CERT_ASSOCIATE, associateData
-    if associateCode != 200
-      return nil
-    end
-    puts associateResponse    
-  end
-
-  def checkExpiry
-    oldCert = ::File.read CERT_PATH
-    certificateObject = OpenSSL::X509::Certificate.new(oldCert)
-    thumbprint = OpenSSL::Digest::SHA1.new(certificateObject.to_der).to_s
-    thumbprint = thumbprint.upcase
-    status, data = get(URL_CERTIFICATE_SEARCH+"?Thumbprint=#{thumbprint}")
-    certInfo = data['Certificates'].first
-    
-    validTo = certInfo['X509']['ValidTo']
-    puts validTo
-    validTo = DateTime.parse("#{validTo}").to_datetime
-    puts validTo
-    validTo = validTo - 10
-    puts validTo
-    currentDate = DateTime.now
-    puts currentDate
-
-    if currentDate > validTo
-      puts "test"
-      renew_request = Vcert::Request.new
-      renew_request.thumbprint = thumbprint
-      renew_cert_id, renew_private_key = @conn.renew(renew_request)
-      renew_request.id=renew_cert_id
-      renew_cert = @conn.retrieve_loop(renew_request)
-      puts "New private key is:\n" + thumbprint_renew_private_key
-      puts "Renewed certificate is:\n" + thumbprint_renew_cert.cert
-      puts "test"
-    else                 
-      puts "test2"
-    end
-  end
+  include VenafiCookbook::Helper
 end

--- a/test/cookbooks/venafi-helper-httpd/attributes/default.rb
+++ b/test/cookbooks/venafi-helper-httpd/attributes/default.rb
@@ -1,0 +1,8 @@
+default['venafi-helper-httpd']['url'] = ''
+default['venafi-helper-httpd']['username'] = ''
+default['venafi-helper-httpd']['password'] = ''
+default['venafi-helper-httpd']['zone'] = ''
+default['venafi-helper-httpd']['common_name'] = ''
+default['venafi-helper-httpd']['location'] = ''
+default['venafi-helper-httpd']['device_name'] = ''
+default['venafi-helper-httpd']['apikey'] = nil

--- a/test/cookbooks/venafi-helper-httpd/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-httpd/recipes/default.rb
@@ -1,50 +1,54 @@
 include_recipe 'venafi-helper::default'
 
-venafihelper 'https://082719192.dev.lab.venafi.com' do
-    tpp_username 'username'
-    tpp_password 'password'
-    policyname   'policyname'
-    commonname   'commoname'
-    location     '/etc/venafi'
-    devicename   'devicename'  
-    action :run
+venafihelper node['venafi-helper-httpd']['common_name'] do
+  tpp_username     node['venafi-helper-httpd']['username']
+  tpp_password     node['venafi-helper-httpd']['password']
+  tpp_url          node['venafi-helper-httpd']['url']
+  apikey           node['venafi-helper-httpd']['apikey']
+  zone             node['venafi-helper-httpd']['zone']
+  location         node['venafi-helper-httpd']['location']
+  app_name         node['venafi-helper-httpd']['app_name']
+  app_info         node['venafi-helper-httpd']['app_info']
+  tls_address      node['venafi-helper-httpd']['tls_address']
+  renew_threshold  node['venafi-helper-httpd']['renew_threshold']
+  action :run
 end
 
 package "httpd" do
-    action [:install]
+  action [:install]
 end
 
 package "mod_ssl" do
-    action [:install]
+  action [:install]
 end
 
 remote_directory '/var/www/html/' do
-    source 'public'
-    owner 'root'
-    group 'root'
-    mode '0755'
-    action :create
+  source 'public'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
 end
 
 template "/etc/httpd/conf.d/ssl.conf" do
-    source "ssl.conf.erb"
-    mode 0644
-    owner "root"
-    group "root"
-    variables(
-            :sslcertificate => "/etc/venafi/orange.example.com.cert",
-            :sslkey => "/etc/venafi/orange.example.com.key",
-            :sslchainfile => "/etc/venafi/orange.example.com.chain"
-            # :servername => "orange.example.com"
-    )
+  source "ssl.conf.erb"
+  mode 0644
+  owner "root"
+  group "root"
+  variables(
+      :sslcertificate => "/etc/venafi/#{node['venafi-helper-httpd']['common_name']}.cert",
+      :sslkey => "/etc/venafi/#{node['venafi-helper-httpd']['common_name']}.key",
+      :sslchainfile => "/etc/venafi/#{node['venafi-helper-httpd']['common_name']}.chain"
+      # :servername => "orange.example.com"
+  )
 end
 
 # change selinux security context for ssl certificates
 execute "change_for_selinux" do
-    command "chcon -Rv --type=httpd_sys_content_t /etc/venafi/"
-    action :run
+  command "chcon -Rv --type=httpd_sys_content_t /etc/venafi/"
+  action :run
 end
 
 service "httpd" do
-    action [:enable,:start]
+  action [:enable,:start]
 end

--- a/test/cookbooks/venafi-helper-nginx/attributes/default.rb
+++ b/test/cookbooks/venafi-helper-nginx/attributes/default.rb
@@ -1,0 +1,8 @@
+default['venafi-helper-nginx']['url'] = ''
+default['venafi-helper-nginx']['username'] = ''
+default['venafi-helper-nginx']['password'] = ''
+default['venafi-helper-nginx']['zone'] = ''
+default['venafi-helper-nginx']['common_name'] = ''
+default['venafi-helper-nginx']['location'] = ''
+default['venafi-helper-nginx']['device_name'] = ''
+default['venafi-helper-nginx']['apikey'] = nil

--- a/test/cookbooks/venafi-helper-nginx/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-nginx/recipes/default.rb
@@ -1,13 +1,17 @@
 include_recipe 'venafi-helper::default'
 
-venafihelper 'https://082719192.dev.lab.venafi.com' do
-    tpp_username 'username'
-    tpp_password 'password'
-    policyname   'policyname'
-    commonname   'commoname'
-    location     '/etc/venafi'
-    devicename   'devicename'  
-    action :run
+venafihelper node['venafi-helper-nginx']['common_name'] do
+  tpp_username     node['venafi-helper-nginx']['username']
+  tpp_password     node['venafi-helper-nginx']['password']
+  tpp_url          node['venafi-helper-nginx']['url']
+  apikey           node['venafi-helper-nginx']['apikey']
+  zone             node['venafi-helper-nginx']['zone']
+  location         node['venafi-helper-nginx']['location']
+  app_name         node['venafi-helper-nginx']['app_name']
+  app_info         node['venafi-helper-nginx']['app_info']
+  tls_address      node['venafi-helper-nginx']['tls_address']
+  renew_threshold  node['venafi-helper-nginx']['renew_threshold']
+  action :run
 end
 
 if platform_family?('rhel')
@@ -25,8 +29,8 @@ end
 template "/etc/nginx/nginx.conf" do
      source "nginx.conf.erb"
      variables(
-        :sslcertificate => "/etc/venafi/orange.example.com.cert",
-        :sslkey => "/etc/venafi/orange.example.com.key",
+      :sslcertificate => "/etc/venafi/#{node['venafi-helper-nginx']['common_name']}.cert",
+      :sslkey => "/etc/venafi/#{node['venafi-helper-nginx']['common_name']}.key",
      )
 end
 

--- a/test/cookbooks/venafi-helper-tomcat/attributes/default.rb
+++ b/test/cookbooks/venafi-helper-tomcat/attributes/default.rb
@@ -1,0 +1,8 @@
+default['venafi-helper-tomcat']['url'] = ''
+default['venafi-helper-tomcat']['username'] = ''
+default['venafi-helper-tomcat']['password'] = ''
+default['venafi-helper-tomcat']['zone'] = ''
+default['venafi-helper-tomcat']['common_name'] = ''
+default['venafi-helper-tomcat']['location'] = ''
+default['venafi-helper-tomcat']['device_name'] = ''
+default['venafi-helper-tomcat']['apikey'] = nil

--- a/test/cookbooks/venafi-helper-tomcat/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-tomcat/recipes/default.rb
@@ -1,13 +1,17 @@
 include_recipe 'venafi-helper::default'
 
-venafihelper 'https://082719192.dev.lab.venafi.com' do
-    tpp_username 'username'
-    tpp_password 'password'
-    policyname   'policyname'
-    commonname   'commoname'
-    location     '/etc/venafi'
-    devicename   'devicename'  
-    action :run
+venafihelper node['venafi-helper-tomcat']['common_name'] do
+  tpp_username     node['venafi-helper-tomcat']['username']
+  tpp_password     node['venafi-helper-tomcat']['password']
+  tpp_url          node['venafi-helper-tomcat']['url']
+  apikey           node['venafi-helper-tomcat']['apikey']
+  zone             node['venafi-helper-tomcat']['zone']
+  location         node['venafi-helper-tomcat']['location']
+  app_name         node['venafi-helper-tomcat']['app_name']
+  app_info         node['venafi-helper-tomcat']['app_info']
+  tls_address      node['venafi-helper-tomcat']['tls_address']
+  renew_threshold  node['venafi-helper-tomcat']['renew_threshold']
+  action :run
 end
 
 if platform_family?('rhel')
@@ -32,8 +36,8 @@ template '/usr/share/tomcat/conf/server.xml' do
   group 'root'
   mode '0644'
   variables(
-    :sslcertificate => "/etc/venafi/orange.example.com.cert",
-    :sslkey => "/etc/venafi/orange.example.com.key",
+      :sslcertificate => "/etc/venafi/#{node['venafi-helper-tomcat']['common_name']}.cert",
+      :sslkey => "/etc/venafi/#{node['venafi-helper-tomcat']['common_name']}.key",
   )
 end
 


### PR DESCRIPTION
Signed-off-by: skylerto <skylerclayne@gmail.com>

This PR allows the end user to use Venafi Cloud as a replacement for Venafi Trust Protection platform if needed (TPP still supported). Because API calls differ between both platforms, all API calls were removed.

Other Changes:
- `vcert` Go client is now used instead of the Ruby Gem. Newer version was required for device registration flags.
- Version pinned to v4.9.6 due to [vcert release URLs being inconsistent](https://github.com/Venafi/vcert/releases)
- Add attributes and better test suite configuration options
- Device registration is now optional

**To Do:**
- Renew functionality is broken for Venafi Cloud (waiting on response from Venafi)
- Document attributes in README