### PR TITLE
Force the app-info/origin to be set for the integration.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,6 @@ suites:
         zone: 'Venafi Partners\Indellient\Infra'
         common_name: 'test.example.com'
         location: '/etc/venafi'
-        app_info: 'test'
         tls_address: '33.33.33.33:443'
         app_name: 'app_name'
         renew_threshold: 1
@@ -77,7 +76,6 @@ suites:
         zone: 'Venafi Partners\Indellient\Infra'
         common_name: 'test.example.com'
         location: '/etc/venafi'
-        app_info: 'test'
         tls_address: '33.33.33.33:443'
         app_name: 'app_name'
         renew_threshold: 1
@@ -117,7 +115,6 @@ suites:
         zone: 'Venafi Partners\Indellient\Infra'
         common_name: 'test.example.com'
         location: '/etc/venafi'
-        app_info: 'test'
         tls_address: '33.33.33.33:443'
         app_name: 'app_name'
         renew_threshold: 1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ In order to use the venafi-helper you need to utilize the custom resource and ca
 - `app_name`:
 - `apikey`: API used to communicate with Venafi Cloud
 - `id_path`:
-- `app_info`:
 - `tls_address`:
 - `renew_threshold`:
 

--- a/resources/venafihelper.rb
+++ b/resources/venafihelper.rb
@@ -32,8 +32,9 @@ action :run do
   key_path = "#{location}/#{key_file}"
   chain_path = "#{location}/#{chain_file}"
   id_path = "#{location}/#{id_file}"
+  app_info = "Indellient-ChefInfra-Helper"
 
-  if !instance.nil? && !new_resource.app_info.nil? && !new_resource.tls_address.nil? && !new_resource.apikey.nil?
+  if !instance.nil? && !new_resource.tls_address.nil? && !new_resource.apikey.nil?
     ::Chef::Application.fatal!('Device Registration not supported on Venafi Cloud')
   end
 
@@ -59,7 +60,7 @@ action :run do
       token: new_resource.token,
       tpp_url: new_resource.tpp_url,
       instance: instance,
-      app_info: new_resource.app_info,
+      app_info: app_info,
       tls_address: new_resource.tls_address
     )
     sensitive true

--- a/test/cookbooks/venafi-helper-httpd/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-httpd/recipes/default.rb
@@ -9,7 +9,6 @@ venafihelper node['venafi-helper-httpd']['common_name'] do
   zone             node['venafi-helper-httpd']['zone']
   location         node['venafi-helper-httpd']['location']
   app_name         node['venafi-helper-httpd']['app_name']
-  app_info         node['venafi-helper-httpd']['app_info']
   tls_address      node['venafi-helper-httpd']['tls_address']
   renew_threshold  node['venafi-helper-httpd']['renew_threshold']
   action :run

--- a/test/cookbooks/venafi-helper-nginx/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-nginx/recipes/default.rb
@@ -9,7 +9,6 @@ venafihelper node['venafi-helper-nginx']['common_name'] do
   zone             node['venafi-helper-nginx']['zone']
   location         node['venafi-helper-nginx']['location']
   app_name         node['venafi-helper-nginx']['app_name']
-  app_info         node['venafi-helper-nginx']['app_info']
   tls_address      node['venafi-helper-nginx']['tls_address']
   renew_threshold  node['venafi-helper-nginx']['renew_threshold']
   action :run

--- a/test/cookbooks/venafi-helper-tomcat/recipes/default.rb
+++ b/test/cookbooks/venafi-helper-tomcat/recipes/default.rb
@@ -9,7 +9,6 @@ venafihelper node['venafi-helper-tomcat']['common_name'] do
   zone             node['venafi-helper-tomcat']['zone']
   location         node['venafi-helper-tomcat']['location']
   app_name         node['venafi-helper-tomcat']['app_name']
-  app_info         node['venafi-helper-tomcat']['app_info']
   tls_address      node['venafi-helper-tomcat']['tls_address']
   renew_threshold  node['venafi-helper-tomcat']['renew_threshold']
   action :run


### PR DESCRIPTION
Based on discussion with Paul:
> 
> I talked with the maintainers of the CLI a little bit and it looks like the Origin field is available, there’s just a name difference in the parameter in the CLI vs the SDK… So, the good news is that it’s available now. In the CLI, it’s referred to as --app-info


This modifies the existing support by hard-coding the app-info flag from the integration.